### PR TITLE
Fixed issue when instance name contains uppercase letters

### DIFF
--- a/src/OwncloudUniversal.OwnCloud/OcsClient.cs
+++ b/src/OwncloudUniversal.OwnCloud/OcsClient.cs
@@ -55,7 +55,7 @@ namespace OwncloudUniversal.OwnCloud
             if (Uri.IsWellFormedUriString(input, UriKind.Absolute))
             {
                 input = input.TrimEnd('/').ToLower();
-                if (input.EndsWith("owncloud") || input.EndsWith("nextcloud"))
+                if (input.EndsWith("owncloud") || input.EndsWith("nextcloud") || input.EndsWith("ownCloud"))
                 {
                     input += "/status.php";
                 }

--- a/src/OwncloudUniversal.OwnCloud/OcsClient.cs
+++ b/src/OwncloudUniversal.OwnCloud/OcsClient.cs
@@ -54,7 +54,7 @@ namespace OwncloudUniversal.OwnCloud
         {
             if (Uri.IsWellFormedUriString(input, UriKind.Absolute))
             {
-                input = input.TrimEnd('/').ToLower();
+                input = input.TrimEnd('/');
                 if (input.EndsWith("owncloud") || input.EndsWith("nextcloud") || input.EndsWith("ownCloud"))
                 {
                     input += "/status.php";


### PR DESCRIPTION
input = input.TrimEnd('/').ToLower(); - makes the input url with lowercase letters. In case the user have uppercase letters in the url, the server is not found;